### PR TITLE
Support python 3.8 and stop publishing to test PyPi

### DIFF
--- a/.github/workflows/publish-to-pypi-manually.yml
+++ b/.github/workflows/publish-to-pypi-manually.yml
@@ -10,11 +10,6 @@ on:
         description: "The git ref to check out from the specified repository."
         required: false
         default: main
-      publish-test-pypi:
-        description: 'Publish to Test PyPi'
-        type: boolean
-        required: true
-        default: true
       publish-pypi:
         description: 'Publish to PyPi'
         type: boolean
@@ -38,24 +33,12 @@ jobs:
       - name: Generate Protocol Classes
         run: protocol-models/bin/generate-python-classes-docker.sh
 
-      - name: Publish Python Package to test.pypi.org
-        if: github.event.inputs.publish-test-pypi
-        uses: mariamrf/py-package-publish-action@v1.1.0
-        with:
-          # specify the same version as in ~/.python-version
-          python_version: "3.9.11"
-          pip_version: "21.1"
-          subdir: "protocol-models/python/"
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"
       - name: Publish Python Package
         if: github.event.inputs.publish-pypi
         uses: mariamrf/py-package-publish-action@v1.1.0
         with:
           # specify the same version as in ~/.python-version
-          python_version: "3.9.11"
+          python_version: "3.8.16"
           pip_version: "21.1"
           subdir: "protocol-models/python/"
         env:

--- a/protocol-models/bin/generate-python-classes-docker.sh
+++ b/protocol-models/bin/generate-python-classes-docker.sh
@@ -10,4 +10,4 @@ ROOT_DIR_NAME=${ROOT_DIR##*/}
 docker run --rm \
   --volume "${ROOT_DIR}:/${ROOT_DIR_NAME}" \
   --workdir "/${ROOT_DIR_NAME}" \
-  python:3.9 "/${ROOT_DIR_NAME}/protocol-models/bin/generate-python-classes.sh"
+  python:3.8 "/${ROOT_DIR_NAME}/protocol-models/bin/generate-python-classes.sh"

--- a/protocol-models/python/setup.py
+++ b/protocol-models/python/setup.py
@@ -47,6 +47,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         # Python Version Support
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.8",
     ],
     keywords="airbyte airbyte-protocol",
     project_urls={
@@ -59,5 +60,5 @@ setup(
     install_requires=[
         "pydantic~=1.9.2",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Supports Py3.8 and stops publishing to test Pypi because test pypi is no longer part of our workflow

I have manually verified there is no diff between models generated with Python 3.8 and those generated with Python 3.9