### PR TITLE
add protocol methods to protocol source

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/protocol_methods.md
+++ b/protocol-models/src/main/resources/airbyte_protocol/protocol_methods.md
@@ -1,5 +1,8 @@
 # Protocol Methods
 
+The purpose of this doc is to define the interface on the docker containers that implement the Airbyte Protocol. It is purposefully lean, as we describe the protocol at length in [our docs](https://docs.airbyte.com/understanding-airbyte/airbyte-protocol). We just want to define the interface here, so that as it evolves, we can version the change as part of the protocol version.
+
+## Method Interfaces
 
 We describe these interfaces in pseudocode for clarity. Clarifications on the pseudocode semantics:
 * Any `Stream~ that is mentioned as input arg, is passed to the docker contained via STDIN. 

--- a/protocol-models/src/main/resources/airbyte_protocol/protocol_methods.md
+++ b/protocol-models/src/main/resources/airbyte_protocol/protocol_methods.md
@@ -1,0 +1,25 @@
+# Protocol Methods
+
+
+We describe these interfaces in pseudocode for clarity. Clarifications on the pseudocode semantics:
+* Any `Stream~ that is mentioned as input arg, is passed to the docker contained via STDIN. 
+* All other parameters are passed in as command line args (e.g. --config <path to config file>). 
+* Each input parameter is described as its type (as defined in airbyte_protocol.yml and the name of the parameter). 
+* If an input parameter has no name, then it is passed via STDIN.
+
+In addition to the return types mentioned below, all methods can return the following message types: `AirbyteLogMessage | AirbyteTraceMessage`.
+
+**interface of both source and destination**
+```
+spec() -> Stream<AirbyteConnectorSpecification>
+check(Config, Optional<ConfiguredCatalog>) -> Stream<AirbyteConnectionStatus>
+```
+**source only**
+```
+discover(Config) -> AirbyteCatalog
+read(Config, ConfiguredAirbyteCatalog, State) -> Stream<AirbyteRecordMessage | AirbyteStateMessage | AirbyteControlMessage>
+```
+**destination only**
+```
+write(Config config, AirbyteCatalog catalog, Stream<AirbyteMessage>) -> Stream<AirbyteStateMessage | AirbyteControlMessage?
+```


### PR DESCRIPTION
Here's a first-pass at adding the protocol methods to the protocol repo. I could not find a way to make JSONSchema to work nicely. Definitely open to other ways of expressing this.