### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
         with:
           ref: main
 
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "17"
+
       # java
       - name: Gradle Build
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
we still use Java 17, so we need to set that up on the runner for the release workflow