### PR TITLE
ci: NPM_TOKEN for npm auth

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -59,4 +59,4 @@ runs:
       shell: bash
       run: cd protocol-models/typescript && npm publish
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+        NPM_TOKEN: ${{ inputs.npm_token }}


### PR DESCRIPTION
Seems like the expected env var for npm auth is NPM_TOKEN