### PR TITLE
feat: Add AirbyteDebugTraceMessage

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -173,9 +173,13 @@ definitions:
         description: "the type of trace message"
         type: string
         enum:
+          - DEBUG
           - ERROR
           - ESTIMATE
           - STREAM_STATUS
+      debug:
+        description: "Debug trace message: extra debugging data"
+        "$ref": "#/definitions/AirbyteDebugTraceMessage"
       emitted_at:
         description: "the time in ms that the message was emitted"
         type: number
@@ -212,6 +216,21 @@ definitions:
       stream_descriptor:
         description: "The stream associated with the error, if known (optional)"
         "$ref": "#/definitions/StreamDescriptor"
+  AirbyteDebugTraceMessage:
+    type: object
+    required:
+      - type
+      - data
+    properties:
+      type:
+        description: The Type of debug message
+        type: string
+      data:
+        description: The Data
+        type: string
+      stream_descriptor:
+        description: The StreamDescriptor for this data
+        “$ref”: "#/definitions/StreamDescriptor"
   AirbyteEstimateTraceMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -4,7 +4,7 @@
 title: AirbyteProtocol
 type: object
 description: AirbyteProtocol structs
-version: 0.3.2
+version: 0.3.3
 properties:
   airbyte_message:
     "$ref": "#/definitions/AirbyteMessage"
@@ -173,9 +173,13 @@ definitions:
         description: "the type of trace message"
         type: string
         enum:
+          - DEBUG
           - ERROR
           - ESTIMATE
           - STREAM_STATUS
+      debug:
+        description: "Debug trace message: extra debugging data"
+        "$ref": "#/definitions/AirbyteDebugTraceMessage"
       emitted_at:
         description: "the time in ms that the message was emitted"
         type: number
@@ -188,6 +192,21 @@ definitions:
       stream_status:
         description: "Stream status trace message:  the current status of a stream within a source"
         "$ref": "#/definitions/AirbyteStreamStatusTraceMessage"
+  AirbyteDebugTraceMessage:
+    type: object
+    required:
+      - type
+      - data
+    properties:
+      type:
+        description: The Type of debug message
+        type: string
+      data:
+        description: The Data
+        type: string
+      stream_descriptor:
+        description: The StreamDescriptor for this data
+        “$ref”: "#/definitions/StreamDescriptor"
   AirbyteErrorTraceMessage:
     type: object
     additionalProperties: true


### PR DESCRIPTION
Add an optional `AirbyteDebugTraceMessage` to enable connectors to emit more debug information.