### PR TITLE
fix: Remove success in favor of explicit status enum values

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -249,7 +249,8 @@ definitions:
     enum:
       - STARTED # Stream has started executing, but no data read yet
       - RUNNING # Stream has read its first byte/message
-      - STOPPED # Stream has stopped executing
+      - COMPLETE # Stream has completed executing without interruption or error
+      - INCOMPLETE # Stream has stopped due to an interruption or error
   AirbyteStreamStatusTraceMessage:
     type: object
     additionalProperties: true
@@ -263,9 +264,6 @@ definitions:
       status:
         description: "The current status of the stream"
         "$ref": "#/definitions/AirbyteStreamStatus"
-      success:
-        description: "Additional flag used with the STOPPED status to indicate success or failure"
-        type: boolean
   AirbyteControlMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -244,7 +244,8 @@ definitions:
     enum:
       - STARTED # Stream has started executing, but no data read yet
       - RUNNING # Stream has read its first byte/message
-      - STOPPED # Stream has stopped executing
+      - COMPLETE # Stream has completed executing without interruption or error
+      - INCOMPLETE # Stream has stopped due to an interruption or error
   AirbyteStreamStatusTraceMessage:
     type: object
     additionalProperties: true
@@ -258,9 +259,6 @@ definitions:
       status:
         description: "The current status of the stream"
         "$ref": "#/definitions/AirbyteStreamStatus"
-      success:
-        description: "Additional flag used with the STOPPED status to indicate success or failure"
-        type: boolean
   AirbyteControlMessage:
     type: object
     additionalProperties: true


### PR DESCRIPTION
Removes the `success` optional field from the `AirbyteStreamStatusTraceMessage` in favor of explicit values in the `AirbyteStreamStatus` enumeration.