### PR TITLE
feat: Support revoking tokens by advanced auth

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -526,6 +526,10 @@ definitions:
           predicate_value:
             description: Value of the predicate_key fields for the advanced auth to be applicable.
             type: string
+          supports_revoking_tokens:
+            description: If the connector OAuth flow supports revoking tokens or not.
+            type: boolean
+            default: false
           oauth_config_specification:
             "$ref": "#/definitions/OAuthConfigSpecification"
       protocol_version:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -521,6 +521,10 @@ definitions:
           predicate_value:
             description: Value of the predicate_key fields for the advanced auth to be applicable.
             type: string
+          supports_revoking_tokens:
+            description: If the connector OAuth flow supports revoking tokens or not.
+            type: boolean
+            default: false
           oauth_config_specification:
             "$ref": "#/definitions/OAuthConfigSpecification"
       protocol_version:


### PR DESCRIPTION
Some APIs require we implement access token revocation to make our apps public. This is a starting point to implement the button: connector's spec tells the platform UI whether to show the button or not.

See https://docs.google.com/document/d/1g5roa5M89pMaCmbx9je11fs_MPo7wNflaCGSmBNCNdI/edit# for more details