### PR TITLE
refactor: Remove authSpecification from Airbyte protocol

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -408,52 +408,6 @@ definitions:
       - overwrite
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
-  OAuth2Specification:
-    type: object
-    additionalProperties: true
-    description: An object containing any metadata needed to describe this connector's Oauth flow. Deprecated, switching to advanced_auth instead
-    properties:
-      rootObject:
-        description:
-          "A list of strings representing a pointer to the root object which contains any oauth parameters in the ConnectorSpecification.
-
-          Examples:
-
-          if oauth parameters were contained inside the top level, rootObject=[]
-          If they were nested inside another object {'credentials': {'app_id' etc...}, rootObject=['credentials']
-          If they were inside a oneOf {'switch': {oneOf: [{client_id...}, {non_oauth_param]}},  rootObject=['switch', 0]
-          "
-        type: array
-        items:
-          oneOf:
-            - type: string
-            - type: integer
-
-      oauthFlowInitParameters:
-        description:
-          "Pointers to the fields in the rootObject needed to obtain the initial refresh/access tokens for the OAuth flow.
-          Each inner array represents the path in the rootObject of the referenced field.
-          For example.
-          Assume the rootObject contains params 'app_secret', 'app_id' which are needed to get the initial refresh token.
-          If they are not nested in the rootObject, then the array would look like this [['app_secret'], ['app_id']]
-          If they are nested inside an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]"
-        type: array
-        items:
-          description: A list of strings denoting a pointer into the rootObject for where to find this property
-          type: array
-          items:
-            type: string
-      oauthFlowOutputParameters:
-        description:
-          "Pointers to the fields in the rootObject which can be populated from successfully completing the oauth flow using the init parameters.
-          This is typically a refresh/access token.
-          Each inner array represents the path in the rootObject of the referenced field."
-        type: array
-        items:
-          description: A list of strings denoting a pointer into the rootObject for where to find this property
-          type: array
-          items:
-            type: string
   ConnectorSpecification:
     type: object
     additionalProperties: true
@@ -496,16 +450,6 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/DestinationSyncMode"
-      authSpecification:
-        description: deprecated, switching to advanced_auth instead
-        type: object
-        properties:
-          auth_type:
-            type: string
-            enum: ["oauth2.0"] # Future auth types should be added here
-          oauth2Specification:
-            description: If the connector supports OAuth, this field should be non-null.
-            "$ref": "#/definitions/OAuth2Specification"
       advanced_auth:
         description: |-
           Additional and optional specification object to describe what an 'advanced' Auth flow would need to function.


### PR DESCRIPTION
## What

Relates to https://github.com/airbytehq/airbyte/issues/15019

[Protocol Change Proposal doc](https://docs.google.com/document/d/1vBAHI9r5qcD8WJc0GXaWEsRrmrvKd4NNvmreUDrqzcA/edit?usp=sharing)

Removes authSpecification from the Airbyte protocol, as it has been replaced by advancedAuth. 

This should only be merged once all connectors in the Airbyte catalog have been migrated to advancedAuth and all references to `authSpecification` have been removed from the Airbyte platform. See the [epic](https://app.zenhub.com/workspaces/connector-extensibility-6257455decf3920012f4e872/issues/gh/airbytehq/airbyte/15019) for the status of the connector migrations.
EDIT: All connectors have now been migrated off of authSpecification, and all references have been removed from the Airbyte platform, so this should now be safe to merge.

## Note for users

Airbyte users and custom connector authors shouldn't need to worry about this change, since `authSpecification` is an internal-only field that requires changes to the Airbyte platform to function, so it should not be used by custom connectors or community members.

The main consequence that users may see is if they upgrade their Airbyte platform to a version in which `authSpecification` is removed, but they are using an old version of a connector that still utilizes `authSpecification`, then they may see an error message in the Airbyte UI when trying to open the connector settings, which will direct them to upgrade to the latest connector version to resolve the issue.