### PR TITLE
fix: Python package - relax pydantic depenency version requirement

### DIFF
--- a/protocol-models/python/setup.py
+++ b/protocol-models/python/setup.py
@@ -58,7 +58,7 @@ setup(
     packages=['airbyte_protocol.models'],
     setup_requires=['python-dotenv'],
     install_requires=[
-        "pydantic~=1.9.2",
+        "pydantic>=1.9.2,<2.0.0",
     ],
     python_requires=">=3.8",
 )


### PR DESCRIPTION
The pydantic version requirement is fairly strict and aligned with the CDK version requirement. As https://github.com/airbytehq/airbyte/pull/28854 will relax the version requirement to everything (equal-)greater than 1.9.2 but lower than 2, this PR aligns the version requirements