### PR TITLE
fix: Skip dont error when invalid jsonSchemaNode is found during traversal

### DIFF
--- a/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemas.java
+++ b/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemas.java
@@ -147,9 +147,10 @@ public class JsonSchemas {
                                                  final List<FieldNameOrList> path,
                                                  final BiConsumer<JsonNode, List<FieldNameOrList>> consumer) {
     if (!jsonSchemaNode.isObject()) {
-      throw new IllegalArgumentException(
-          String.format("json schema nodes should always be object nodes. path: %s actual: %s", path, jsonSchemaNode));
+      log.warn("Skipping Invalid node: json schema nodes should always be object nodes. path: {} actual: {}", path, jsonSchemaNode);
+      return;
     }
+
     consumer.accept(jsonSchemaNode, path);
     // if type is missing assume object. not official JsonSchema, but it seems to be a common
     // compromise.

--- a/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemas.java
+++ b/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemas.java
@@ -146,11 +146,12 @@ public class JsonSchemas {
   private static void traverseJsonSchemaInternal(final JsonNode jsonSchemaNode,
                                                  final List<FieldNameOrList> path,
                                                  final BiConsumer<JsonNode, List<FieldNameOrList>> consumer) {
-    if (!jsonSchemaNode.isObject()) {
-      log.warn("Skipping Invalid node: json schema nodes should always be object nodes. path: {} actual: {}", path, jsonSchemaNode);
+    final boolean isTraversable = jsonSchemaNode.isObject();
+    if (!isTraversable) {
+      log.warn("json schema nodes should always be object nodes. path: {} actual: {}",
+          path, jsonSchemaNode);
       return;
     }
-
     consumer.accept(jsonSchemaNode, path);
     // if type is missing assume object. not official JsonSchema, but it seems to be a common
     // compromise.

--- a/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -131,6 +131,7 @@ class CatalogHelpersTest {
         StreamTransform.createRemoveStreamTransform(new StreamDescriptor().withName("accounts")),
         StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
             FieldTransform.createAddFieldTransform(List.of("COD"), schema2.get(PROPERTIES).get("COD")),
+            FieldTransform.createAddFieldTransform(List.of("somePreviouslyInvalidField"), schema2.get(PROPERTIES).get("somePreviouslyInvalidField")),
             FieldTransform.createRemoveFieldTransform(List.of("something2"), schema1.get(PROPERTIES).get("something2"), false),
             FieldTransform.createRemoveFieldTransform(List.of("HKD"), schema1.get(PROPERTIES).get("HKD"), false),
             FieldTransform.createUpdateFieldTransform(List.of(CAD), new UpdateFieldSchemaTransform(

--- a/protocol-models/src/test/resources/valid_schema.json
+++ b/protocol-models/src/test/resources/valid_schema.json
@@ -10,6 +10,7 @@
     "DKK": { "type": ["null", "number"] },
     "HUF": { "type": ["null", "number"] },
     "文": { "type": ["null", "number"] },
+    "somePreviouslyInvalidField": [null, "integer"],
     "something": {
       "type": ["null", "object"],
       "properties": {

--- a/protocol-models/src/test/resources/valid_schema2.json
+++ b/protocol-models/src/test/resources/valid_schema2.json
@@ -10,6 +10,9 @@
     "DKK": { "type": ["null", "number"] },
     "HUF": { "type": ["null", "number"] },
     "文": { "type": ["null", "number"] },
+    "somePreviouslyInvalidField": {
+      "type": ["null", "integer"]
+    },
     "something": {
       "type": ["null", "object"],
       "properties": {


### PR DESCRIPTION
# Overview
Related to https://github.com/airbytehq/oncall/issues/2703

The goal is to relax the hard requirement of the json node being an object.

## Why?
The release of a new stripe catalog revealed that
1. We had been successfully using a catalog for 2 months with a node considered invalid by this diff tool
2. That this diff tool would fail when prevented with a valid json object, that we just didnt like

Because of this we opted to change the behaviour of this diff to simply skip the node.

This then causes the diff to treat the field as a new field when it becomes valid

## Alternatives considered
### 1. A migration of catalogs
We could have edited all catalogs and configured catalogs in the last two months for stripe but that was deemed to risky and didnt solve the root issue

### 2. Traverse the array instead of skip
We could make this so the diff treats the change from invalid type to valid as an update. But that makes less sense

