### PR TITLE
refactor: Add analytics trace message type

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -270,6 +270,17 @@ definitions:
   AirbyteAnalyticsTraceMessage:
     type: object
     additionalProperties: true
+    description:
+      "A message to communicate usage information about the connector which is not captured by regular sync analytics because it's specific to the connector internals.
+      This is useful to understand how the connector is used and how to improve it.
+      Each message is an event with a type and an optional payload value (both of them being strings). The event types should not be dynamically generated but defined statically.
+      The payload value is optional and can contain arbitrary strings.
+      "
+    examples:
+      - type: "sql-source-used-cursor-count-indexed"
+        value: "2"
+      - type: "mongodb-cluster-version"
+        value: "6.5"
     required:
       - type
     properties:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -176,6 +176,7 @@ definitions:
           - ERROR
           - ESTIMATE
           - STREAM_STATUS
+          - ANALYTICS
       emitted_at:
         description: "the time in ms that the message was emitted"
         type: number
@@ -188,6 +189,8 @@ definitions:
       stream_status:
         description: "Stream status trace message:  the current status of a stream within a source"
         "$ref": "#/definitions/AirbyteStreamStatusTraceMessage"
+      analytics:
+        "$ref": "#/definitions/AirbyteAnalyticsTraceMessage"
   AirbyteErrorTraceMessage:
     type: object
     additionalProperties: true
@@ -264,6 +267,18 @@ definitions:
       status:
         description: "The current status of the stream"
         "$ref": "#/definitions/AirbyteStreamStatus"
+  AirbyteAnalyticsTraceMessage:
+    type: object
+    additionalProperties: true
+    required:
+      - type
+    properties:
+      type:
+        description: "the event type"
+        type: string
+      value:
+        type: string
+        description: "the value of the event"
   AirbyteControlMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -176,6 +176,7 @@ definitions:
           - ERROR
           - ESTIMATE
           - STREAM_STATUS
+          - ANALYTICS
       emitted_at:
         description: "the time in ms that the message was emitted"
         type: number
@@ -188,6 +189,8 @@ definitions:
       stream_status:
         description: "Stream status trace message:  the current status of a stream within a source"
         "$ref": "#/definitions/AirbyteStreamStatusTraceMessage"
+      analytics:
+        "$ref": "#/definitions/AirbyteAnalyticsTraceMessage"
   AirbyteErrorTraceMessage:
     type: object
     additionalProperties: true
@@ -259,6 +262,18 @@ definitions:
       status:
         description: "The current status of the stream"
         "$ref": "#/definitions/AirbyteStreamStatus"
+  AirbyteAnalyticsTraceMessage:
+    type: object
+    additionalProperties: true
+    required:
+      - type
+    properties:
+      type:
+        description: "the event type"
+        type: string
+      value:
+        type: string
+        description: "the value of the event"
   AirbyteControlMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -265,6 +265,17 @@ definitions:
   AirbyteAnalyticsTraceMessage:
     type: object
     additionalProperties: true
+    description:
+      "A message to communicate usage information about the connector which is not captured by regular sync analytics because it's specific to the connector internals.
+      This is useful to understand how the connector is used and how to improve it.
+      Each message is an event with a type and an optional payload value (both of them being strings). The event types should not be dynamically generated but defined statically.
+      The payload value is optional and can contain arbitrary strings.
+      "
+    examples:
+      - type: "sql-source-used-cursor-count-indexed"
+        value: "2"
+      - type: "mongodb-cluster-version"
+        value: "6.5"
     required:
       - type
     properties:


### PR DESCRIPTION
Adds analytics trace message according to https://docs.google.com/document/d/1ZYoCs79GAfTn-x0RL76r4gWm1IWXqJ0cMP5K1RUPeWM/edit

This is not a publicly documented message type and mostly intended for internal use. Because of this, it's marked as a refactoring similar to https://github.com/airbytehq/airbyte-protocol/pull/39