### PR TITLE
feat: Add spec_migration_version to connector specification

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -502,6 +502,12 @@ definitions:
       protocol_version:
         description: "the Airbyte Protocol version supported by the connector. Protocol versioning uses SemVer. "
         type: string
+      spec_migration_version:
+        type: integer
+            description: |-
+              The version of the spec - if there is a change that requires to migrate the config of an actor, this number should be incremented.
+              This allows the platform to track whether a persisted config object is up to date or not.
+              Specifying a version is optional, but if a version of the connector specifies it, all subsequent versions must specify it as well. The number must either be incremented or stay the same.
   OAuthConfigSpecification:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -553,6 +553,12 @@ definitions:
       protocol_version:
         description: "the Airbyte Protocol version supported by the connector. Protocol versioning uses SemVer. "
         type: string
+      spec_migration_version:
+        type: integer
+            description: |-
+              The version of the spec - if there is a change that requires to migrate the config of an actor, this number should be incremented.
+              This allows the platform to track whether a persisted config object is up to date or not.
+              Specifying a version is optional, but if a version of the connector specifies it, all subsequent versions must specify it as well. The number must either be incremented or stay the same.
   OAuthConfigSpecification:
     type: object
     additionalProperties: true


### PR DESCRIPTION
Add an optional `spec_migration_version` property to the connector specification.

When upgrading connector versions, the connector spec that all persisted config objects have to adhere to might change. While connectors are required to also be able to handle config objects that got created for previous versions of the connector as long as no explicit breaking change occurred, the connector itself is not the only consumer of config objects: The Airbyte UI and API clients access configuration objects as well - in these cases a spec change can have unintended consequences. For example if a field gets renamed from user_name to username), the UI won’t be able to render the configuration form correctly.

A new optional field in the connector specification allows the platform to keep track of the compatibility level of persisted actor configurations and behave accordingly.

The following changes are made to the protocol contract:
* An optional integer field `spec_migration_version` might be defined by a connector as part of the connector specification returned for the SPEC command.
* The `spec_migration_version` can be used to inform the orchestrator that persisted actor configs created for a connector version with a different `spec_migration_version` are not considered compatible with the current `connectionSpecification` of the connector.
* If a `spec_migration_version` is defined by a connector, all subsequent versions of the connector have to define it as well.
* A `spec_migration_version` is not allowed to be decremented in a subsequent version of the connector.

Note: Compatibility can be related to a spec change that makes persisted configuration objects from previous versions incompatible in the JSON schema sense (e.g. a field type changes from number to string) or in the logical sense (e.g. a pre-existing field has a different meaning now).
