### PR TITLE
fix: only add user selected streams to the catalog diff

### DIFF
--- a/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -377,7 +377,7 @@ public class CatalogHelpers {
                   && s.getStream().getName().equals(descriptor.getName()))
               .findFirst();
 
-          if (!streamOld.equals(streamNew)) {
+          if (!streamOld.equals(streamNew) && stream.isPresent()) {
             // getStreamDiff only checks for differences in the stream's field name or field type
             // but there are a number of reasons the streams might be different (such as a source-defined
             // primary key or cursor changing). These should not be expressed as "stream updates".

--- a/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -278,12 +278,6 @@ class CatalogHelpersTest {
 
     final Set<StreamTransform> diff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
 
-    final List<StreamTransform> expectedDiff = Stream.of(
-        StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
-            FieldTransform.createRemoveFieldTransform(List.of(DATE), schema1.get(PROPERTIES).get(DATE), false),
-            FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), false)))))
-        .toList();
-
     //configuredCatalog is for a different stream, so no diff should be found
     Assertions.assertThat(diff).hasSize(0);
   }

--- a/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -284,7 +284,8 @@ class CatalogHelpersTest {
             FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), false)))))
         .toList();
 
-    Assertions.assertThat(diff).containsAll(expectedDiff);
+    //configuredCatalog is for a different stream, so no diff should be found
+    Assertions.assertThat(diff).hasSize(0);
   }
 
   @Test


### PR DESCRIPTION
Function `getCatalogDiff` compares the existing source catalog with the newly discovered one and if there's a difference, it includes the corresponding stream in the update that shows up in the UI. However, a given stream may not be toggled (selected) by the customer,  thus it should not be included in the update. This change ensures that, in addition to doing a comparison between the new and old catalog, the configured catalog must also be present. Inactive streams will not show up in the ConfiguredCatalog.

Solves https://github.com/airbytehq/airbyte/issues/23361