### PR TITLE
feat: `AirbyteRecordMessageMeta` for per-record lineage and changes

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -73,6 +73,28 @@ definitions:
       emitted_at:
         description: "when the data was emitted from the source. epoch in millisecond."
         type: integer
+      meta:
+        description: Information about this record added mid-sync
+        "$ref": "#/definitions/AirbyteRecordMessageMeta"
+  AirbyteRecordMessageMeta:
+    type: object
+    additionalProperties: true
+    properties:
+      property_errors:
+        description: Key-Value pairs of problems for properties of this record
+        type: array
+        items: "#/definitions/AirbyteRecordMessageMetaPropertyError"
+  AirbyteRecordMessageMetaPropertyError:
+    type: object
+    additionalProperties: true
+    required:
+      - key
+      - message
+    properties:
+      key:
+        type: string
+      message:
+        type: string
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -81,7 +81,7 @@ definitions:
     additionalProperties: true
     properties:
       changes:
-        description: Lists of problems with the properties of this record, and where they originated
+        description: Lists of changes to the content of this record which occurred during syncing
         type: array
         items:
           "$ref": "#/definitions/AirbyteRecordMessageMetaChange"

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -80,11 +80,11 @@ definitions:
     type: object
     additionalProperties: true
     properties:
-      property_errors:
+      errors:
         description: Key-Value pairs of problems for properties of this record
         type: array
-        items: "#/definitions/AirbyteRecordMessageMetaPropertyError"
-  AirbyteRecordMessageMetaPropertyError:
+        items: "#/definitions/AirbyteRecordMessageMetaErrors"
+  AirbyteRecordMessageMetaErrors:
     type: object
     additionalProperties: true
     required:
@@ -94,6 +94,8 @@ definitions:
       key:
         type: string
       message:
+        type: string
+      origin:
         type: string
   AirbyteStateMessage:
     type: object

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -105,12 +105,20 @@ definitions:
         type: string
         description: The reason that the change occurred
         enum:
-          - SOURCE_LIMITATION
-          - DESTINATION_LIMITATION
-          - PLATFORM_LIMITATION
-      message:
-        description: Human-readable explanation of why the change occurred
-        type: string
+          # The record, in aggregate, was too large to be processed
+          - SOURCE_RECORD_SIZE_LIMITATION
+          - DESTINATION_RECORD_SIZE_LIMITATION
+          - PLATFORM_RECORD_SIZE_LIMITATION
+          # A single field, was too large to be processed
+          - SOURCE_FIELD_SIZE_LIMITATION
+          - DESTINATION_FIELD_SIZE_LIMITATION
+          - PLATFORM_FIELD_SIZE_LIMITATION
+          # The field could not be read or written
+          - SOURCE_SERIALIZATION_ERROR
+          - DESTINATION_SERIALIZATION_ERROR
+          - PLATFORM_SERIALIZATION_ERROR
+          # Errors producing the field
+          - SOURCE_RETRIEVAL_ERROR
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -96,12 +96,6 @@ definitions:
         type: string
       message:
         type: string
-      origin:
-        type: string
-        enum:
-          - SOURCE
-          - DESTINATION
-          - PLATFORM
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -80,23 +80,25 @@ definitions:
     type: object
     additionalProperties: true
     properties:
-      errors:
+      changes:
         description: Lists of problems with the properties of this record, and where they originated
         type: array
         items:
-          "$ref": "#/definitions/AirbyteRecordMessageMetaErrors"
-  AirbyteRecordMessageMetaErrors:
+          "$ref": "#/definitions/AirbyteRecordMessageMetaChanges"
+  AirbyteRecordMessageMetaChanges:
     type: object
     additionalProperties: true
     required:
       - field
-      - message
     properties:
       field:
         type: string
-      message:
+      change:
         type: string
-  AirbyteStateMessage:
+        enum:
+          - NULLED
+      reason:
+        type: string
     type: object
     additionalProperties: true
     properties:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -98,6 +98,10 @@ definitions:
         type: string
       origin:
         type: string
+        enum:
+          - SOURCE
+          - DESTINATION
+          - PLATFORM
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -83,8 +83,9 @@ definitions:
       errors:
         description: Key-Value pairs of problems for properties of this record
         type: array
-        items: "#/definitions/AirbyteRecordMessageMetaErrors"
-  AirbyteRecordMessageMetaErrors:
+        items:
+          "$ref": "#/definitions/AirbyteRecordMessageMetaErrors"
+  AirbyteRecordMessageMetaPropertyErrors:
     type: object
     additionalProperties: true
     required:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -81,7 +81,7 @@ definitions:
     additionalProperties: true
     properties:
       errors:
-        description: Key-Value pairs of problems for properties of this record
+        description: Lists of problems with the properties of this record, and where they originated
         type: array
         items:
           "$ref": "#/definitions/AirbyteRecordMessageMetaErrors"
@@ -89,10 +89,10 @@ definitions:
     type: object
     additionalProperties: true
     required:
-      - key
+      - property
       - message
     properties:
-      key:
+      property:
         type: string
       message:
         type: string

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -89,10 +89,10 @@ definitions:
     type: object
     additionalProperties: true
     required:
-      - property
+      - field
       - message
     properties:
-      property:
+      field:
         type: string
       message:
         type: string

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -84,8 +84,8 @@ definitions:
         description: Lists of problems with the properties of this record, and where they originated
         type: array
         items:
-          "$ref": "#/definitions/AirbyteRecordMessageMetaChanges"
-  AirbyteRecordMessageMetaChanges:
+          "$ref": "#/definitions/AirbyteRecordMessageMetaChange"
+  AirbyteRecordMessageMetaChange:
     type: object
     additionalProperties: true
     required:
@@ -93,11 +93,14 @@ definitions:
     properties:
       field:
         type: string
+        description: The field that had the change occur (required)
       change:
         type: string
+        description: The type of change that occurred
         enum:
           - NULLED
       reason:
+        description: Human-readable explanation of why the change occurred
         type: string
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -91,6 +91,7 @@ definitions:
     required:
       - field
       - reason
+      - change
     properties:
       field:
         type: string

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -90,6 +90,7 @@ definitions:
     additionalProperties: true
     required:
       - field
+      - reason
     properties:
       field:
         type: string
@@ -100,6 +101,13 @@ definitions:
         enum:
           - NULLED
       reason:
+        type: string
+        description: The reason that the change occurred
+        enum:
+          - SOURCE_LIMITATION
+          - DESTINATION_LIMITATION
+          - PLATFORM_LIMITATION
+      message:
         description: Human-readable explanation of why the change occurred
         type: string
   AirbyteStateMessage:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -102,6 +102,7 @@ definitions:
       reason:
         description: Human-readable explanation of why the change occurred
         type: string
+  AirbyteStateMessage:
     type: object
     additionalProperties: true
     properties:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -101,6 +101,7 @@ definitions:
         description: The type of change that occurred
         enum:
           - NULLED
+          - TRUNCATED
       reason:
         type: string
         description: The reason that the change occurred

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -85,7 +85,7 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/AirbyteRecordMessageMetaErrors"
-  AirbyteRecordMessageMetaPropertyErrors:
+  AirbyteRecordMessageMetaErrors:
     type: object
     additionalProperties: true
     required:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -100,6 +100,10 @@ definitions:
         type: string
       origin:
         type: string
+        enum:
+          - SOURCE
+          - DESTINATION
+          - PLATFORM
 
   AirbyteStateMessage:
     type: object

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -103,6 +103,7 @@ definitions:
         description: The type of change that occurred
         enum:
           - NULLED
+          - TRUNCATED
       reason:
         type: string
         description: The reason that the change occurred

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -81,12 +81,12 @@ definitions:
     type: object
     additionalProperties: true
     properties:
-      property_errors:
+      errors:
         description: Key-Value pairs of problems for properties of this record
         type: array
-        items: "#/definitions/AirbyteRecordMessageMetaPropertyError"
+        items: "#/definitions/AirbyteRecordMessageMetaErrors"
 
-  AirbyteRecordMessageMetaPropertyError:
+  AirbyteRecordMessageMetaErrors:
     type: object
     additionalProperties: true
     required:
@@ -96,6 +96,8 @@ definitions:
       key:
         type: string
       message:
+        type: string
+      origin:
         type: string
 
   AirbyteStateMessage:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -85,9 +85,9 @@ definitions:
         description: Lists of problems with the properties of this record, and where they originated
         type: array
         items:
-          "$ref": "#/definitions/AirbyteRecordMessageMetaChanges"
+          "$ref": "#/definitions/AirbyteRecordMessageMetaChange"
 
-  AirbyteRecordMessageMetaChanges:
+  AirbyteRecordMessageMetaChange:
     type: object
     additionalProperties: true
     required:
@@ -95,11 +95,14 @@ definitions:
     properties:
       field:
         type: string
+        description: The field that had the change occur (required)
       change:
         type: string
+        description: The type of change that occurred
         enum:
           - NULLED
       reason:
+        description: Human-readable explanation of why the change occurred
         type: string
 
   AirbyteStateMessage:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -73,6 +73,31 @@ definitions:
       emitted_at:
         description: "when the data was emitted from the source. epoch in millisecond."
         type: integer
+      meta:
+        description: Information about this record added mid-sync
+        "$ref": "#/definitions/AirbyteRecordMessageMeta"
+
+  AirbyteRecordMessageMeta:
+    type: object
+    additionalProperties: true
+    properties:
+      property_errors:
+        description: Key-Value pairs of problems for properties of this record
+        type: array
+        items: "#/definitions/AirbyteRecordMessageMetaPropertyError"
+
+  AirbyteRecordMessageMetaPropertyError:
+    type: object
+    additionalProperties: true
+    required:
+      - key
+      - message
+    properties:
+      key:
+        type: string
+      message:
+        type: string
+
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -81,22 +81,25 @@ definitions:
     type: object
     additionalProperties: true
     properties:
-      errors:
+      changes:
         description: Lists of problems with the properties of this record, and where they originated
         type: array
         items:
-          "$ref": "#/definitions/AirbyteRecordMessageMetaErrors"
+          "$ref": "#/definitions/AirbyteRecordMessageMetaChanges"
 
-  AirbyteRecordMessageMetaErrors:
+  AirbyteRecordMessageMetaChanges:
     type: object
     additionalProperties: true
     required:
       - field
-      - message
     properties:
       field:
         type: string
-      message:
+      change:
+        type: string
+        enum:
+          - NULLED
+      reason:
         type: string
 
   AirbyteStateMessage:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -93,6 +93,7 @@ definitions:
     required:
       - field
       - reason
+      - change
     properties:
       field:
         type: string

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -82,7 +82,7 @@ definitions:
     additionalProperties: true
     properties:
       errors:
-        description: Key-Value pairs of problems for properties of this record
+        description: Lists of problems with the properties of this record, and where they originated
         type: array
         items:
           "$ref": "#/definitions/AirbyteRecordMessageMetaErrors"
@@ -91,10 +91,10 @@ definitions:
     type: object
     additionalProperties: true
     required:
-      - key
+      - property
       - message
     properties:
-      key:
+      property:
         type: string
       message:
         type: string

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -91,10 +91,10 @@ definitions:
     type: object
     additionalProperties: true
     required:
-      - property
+      - field
       - message
     properties:
-      property:
+      field:
         type: string
       message:
         type: string

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -92,6 +92,7 @@ definitions:
     additionalProperties: true
     required:
       - field
+      - reason
     properties:
       field:
         type: string
@@ -102,6 +103,13 @@ definitions:
         enum:
           - NULLED
       reason:
+        type: string
+        description: The reason that the change occurred
+        enum:
+          - SOURCE_LIMITATION
+          - DESTINATION_LIMITATION
+          - PLATFORM_LIMITATION
+      message:
         description: Human-readable explanation of why the change occurred
         type: string
 

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -84,7 +84,8 @@ definitions:
       errors:
         description: Key-Value pairs of problems for properties of this record
         type: array
-        items: "#/definitions/AirbyteRecordMessageMetaErrors"
+        items:
+          "$ref": "#/definitions/AirbyteRecordMessageMetaErrors"
 
   AirbyteRecordMessageMetaErrors:
     type: object

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -82,7 +82,7 @@ definitions:
     additionalProperties: true
     properties:
       changes:
-        description: Lists of problems with the properties of this record, and where they originated
+        description: Lists of changes to the content of this record which occurred during syncing
         type: array
         items:
           "$ref": "#/definitions/AirbyteRecordMessageMetaChange"

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -107,12 +107,20 @@ definitions:
         type: string
         description: The reason that the change occurred
         enum:
-          - SOURCE_LIMITATION
-          - DESTINATION_LIMITATION
-          - PLATFORM_LIMITATION
-      message:
-        description: Human-readable explanation of why the change occurred
-        type: string
+          # The record, in aggregate, was too large to be processed
+          - SOURCE_RECORD_SIZE_LIMITATION
+          - DESTINATION_RECORD_SIZE_LIMITATION
+          - PLATFORM_RECORD_SIZE_LIMITATION
+          # A single field, was too large to be processed
+          - SOURCE_FIELD_SIZE_LIMITATION
+          - DESTINATION_FIELD_SIZE_LIMITATION
+          - PLATFORM_FIELD_SIZE_LIMITATION
+          # The field could not be read or written
+          - SOURCE_SERIALIZATION_ERROR
+          - DESTINATION_SERIALIZATION_ERROR
+          - PLATFORM_SERIALIZATION_ERROR
+          # Errors producing the field
+          - SOURCE_RETRIEVAL_ERROR
 
   AirbyteStateMessage:
     type: object

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -98,12 +98,6 @@ definitions:
         type: string
       message:
         type: string
-      origin:
-        type: string
-        enum:
-          - SOURCE
-          - DESTINATION
-          - PLATFORM
 
   AirbyteStateMessage:
     type: object

--- a/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -278,7 +278,7 @@ class CatalogHelpersTest {
 
     final Set<StreamTransform> diff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
 
-    //configuredCatalog is for a different stream, so no diff should be found
+    // configuredCatalog is for a different stream, so no diff should be found
     Assertions.assertThat(diff).hasSize(0);
   }
 
@@ -305,4 +305,5 @@ class CatalogHelpersTest {
 
     Assertions.assertThat(actualDiff).containsExactlyInAnyOrderElementsOf(expectedDiff);
   }
+
 }


### PR DESCRIPTION
[Related Doc](https://docs.google.com/document/d/1eujDX1katRSwfWEploscqPthoO6etV5_q-Xy7wVn4vw/edit) and [Protocol Change Doc](https://docs.google.com/document/d/1yLUWO569E7WJJtC-v284fEq4AXNQoKJ5o4bLHxf2acI/edit)

In order to help track the lineage of record changes along throughout a sync, a new _optional_ property is added to `AirbyteRecordMessage` that will store per-record errors that will eventually be stored in the destination.  

As a reminder of our starting assumptions:
* "data errors" are not "sync errors", and therefore should not block/fail a sync.
* Some data is just too big to process or store.
* Any part of the Airbyte platform might need to modify a record field for size reasons.  

For example, consider the following totally realistic example record:

```js
{
  type: "RECORD",
  record: {
    stream: "users",
    emitted_at: 123456789,
    data: {
      id: 1,
      first_name: "evan",
      last_name: "tahler",
      image: "<40mb PNG image... PNGxxxxxxyyyyyzzzz>"
    }
  }
}
```

While the source might be able to handle serializing the record, the platform (with its current limit of 20mb per field), will not.  To keep the lineage that the `image` field was modified, we add a new `meta.errors` array which contains the change information.  After the record passes though the platform, it will look like:

```js
{
  type: "RECORD",
  record: {
    stream: "users",
    emitted_at: 123456789,
    data: {
      id: 1,
      first_name: "evan",
      last_name: "tahler",
      image: null // <--- changed!
    },
    meta: {
      changes: [
        { field: "image", change: "NULLED", reason: "PLATFORM_FIELD_SIZE_LIMITATION" }
      ]
    } 
  }
}
```

V2 destinations will then be able to inspect the record's `meta` information, and pass that along to the data warehouse, producing per-row errors.  While the protocol wishes to track these changes as "changes", destinations are likely to represent these changes as errors for users. 

In the threads below, we discussed how we would represent an error with a sub-field.  We decided on JSON-schema representations of the problematic properties: 

```js
{
  type: "RECORD",
  record: {
    stream: "users",
    emitted_at: 123456789,
    data: {
      id: 1,
      first_name: "evan",
      last_name: "tahler",
      image: {
        name: "profile.png",
        body // <--- changed!
      }
    },
    meta: {
      changes: [
        { field: "image.body", change: "NULLED", reason: "PLATFORM_FIELD_SIZE_LIMITATION"}
      ]
    } 
  }
}
```