### PR TITLE
fix: Add py.typed to python distribution

### DIFF
--- a/protocol-models/python/setup.py
+++ b/protocol-models/python/setup.py
@@ -56,6 +56,7 @@ setup(
         "Tracker": "https://github.com/airbytehq/airbyte-protocol/issues",
     },
     packages=['airbyte_protocol.models'],
+    package_data={"airbyte_protocol": ["py.typed"]},
     setup_requires=['python-dotenv'],
     install_requires=[
         "pydantic>=1.9.2,<2.0.0",


### PR DESCRIPTION
Currently, the python distribution of the protocol models doesn't have a [`py.typed` file](https://peps.python.org/pep-0561/) which throws off mypy. This PR fixes this issue