### PR TITLE
fix: Removed unused V1.

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/v1/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v1/airbyte_protocol.yaml
@@ -1,1 +1,0 @@
-../airbyte_protocol.yaml


### PR DESCRIPTION
We do not use V1. Instead of duplicate, potential drift and confusion, let's remove V1 for now and re-introduce when we are ready to move to V1.