### PR TITLE
feat: `AirbyteControlSyncWorkflowCorrectionMessage`

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -335,7 +335,7 @@ definitions:
         description: "the config items from this connector's spec to update"
         type: object
         additionalProperties: true
-    AirbyteControlSyncWorkflowCorrectionMessage:
+  AirbyteControlSyncWorkflowCorrectionMessage:
     type: object
     additionalProperties: true
     required:
@@ -352,7 +352,7 @@ definitions:
         items:
           "$ref": "#/definitions/StreamDescriptor"
       type:
-    "$ref": "#/definitions/AirbyteStateType" # (global or per-stream)
+        "$ref": "#/definitions/AirbyteStateType" # (global or per-stream)
       message:
         description: A user-friendly message that describes the problem. This message will be logged and displayed to the user
         type: string

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -315,12 +315,16 @@ definitions:
         type: string
         enum:
           - CONNECTOR_CONFIG
+          - SYNC_WORKFLOW_CORRECTION
       emitted_at:
         description: "the time in ms that the message was emitted"
         type: number
       connectorConfig:
         description: "connector config orchestrator message: the updated config for the platform to store for this connector"
         "$ref": "#/definitions/AirbyteControlConnectorConfigMessage"
+      syncWorkflowCorrection:
+        description: "connector config orchestrator message: a sync workflow correction is needed"
+        "$ref": "#/definitions/AirbyteControlSyncWorkflowCorrectionMessage"
   AirbyteControlConnectorConfigMessage:
     type: object
     additionalProperties: true
@@ -331,6 +335,27 @@ definitions:
         description: "the config items from this connector's spec to update"
         type: object
         additionalProperties: true
+    AirbyteControlSyncWorkflowCorrectionMessage:
+    type: object
+    additionalProperties: true
+    required:
+      - correctionType
+      - type
+      - message
+    properties:
+      correctionType:
+        enum:
+          - FULL_RESYNC_STARTED
+          # in future we can have WAIT_NEXT_ATTEMPT, for when the source hits the global rate limit, for example
+      streams:
+        type: array
+        items:
+          "$ref": "#/definitions/StreamDescriptor"
+      type:
+    "$ref": "#/definitions/AirbyteStateType" # (global or per-stream)
+      message:
+        description: A user-friendly message that describes the problem. This message will be logged and displayed to the user
+        type: string
   AirbyteConnectionStatus:
     type: object
     description: Airbyte connection status

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -315,12 +315,16 @@ definitions:
         type: string
         enum:
           - CONNECTOR_CONFIG
+          - SYNC_WORKFLOW_CORRECTION
       emitted_at:
         description: "the time in ms that the message was emitted"
         type: number
       connectorConfig:
         description: "connector config orchestrator message: the updated config for the platform to store for this connector"
         "$ref": "#/definitions/AirbyteControlConnectorConfigMessage"
+      syncWorkflowCorrection:
+        description: "connector config orchestrator message: a sync workflow correction is needed"
+        "$ref": "#/definitions/AirbyteControlSyncWorkflowCorrectionMessage"
   AirbyteControlConnectorConfigMessage:
     type: object
     additionalProperties: true
@@ -331,6 +335,27 @@ definitions:
         description: "the config items from this connector's spec to update"
         type: object
         additionalProperties: true
+  AirbyteControlSyncWorkflowCorrectionMessage:
+    type: object
+    additionalProperties: true
+    required:
+      - correctionType
+      - type
+      - message
+    properties:
+      correctionType:
+        enum:
+          - FULL_RESYNC_STARTED
+          # in future we can have WAIT_NEXT_ATTEMPT, for when the source hits the global rate limit, for example
+      streams:
+        type: array
+        items:
+          "$ref": "#/definitions/StreamDescriptor"
+      type:
+    "$ref": "#/definitions/AirbyteStateType" # (global or per-stream)
+      message:
+        description: A user-friendly message that describes the problem. This message will be logged and displayed to the user
+        type: string
   AirbyteConnectionStatus:
     type: object
     description: Airbyte connection status

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -352,7 +352,7 @@ definitions:
         items:
           "$ref": "#/definitions/StreamDescriptor"
       type:
-    "$ref": "#/definitions/AirbyteStateType" # (global or per-stream)
+        "$ref": "#/definitions/AirbyteStateType" # (global or per-stream)
       message:
         description: A user-friendly message that describes the problem. This message will be logged and displayed to the user
         type: string


### PR DESCRIPTION
Links:
* [Change Proposal](https://docs.google.com/document/d/1Vo3pg8zixaMGyHJcM1lnwxe7W6tZhHimgoH86gD_tt8/edit)
* Slack Channel: `#proj-handle-source-enforced-full-reset`

We propose creating a new control message `AirbyteControlSyncWorkflowCorrectionMessage` that is sent by Database Source Connectors when incremental data updates (deltas) cannot be processed successfully, and the source connector initiates a full refresh of the dataset from the datastore. When partial updates are unreliable, a full refresh ensures data consistency. The control message is named by design to be more reflective of any sync data problems that source runs into in future.  This scenario can occur when a CDC replicating sync has waited longer than the WAL retention period between syncs.

The purpose of this control message is to notify the Airbyte stack that any data preceding this message for the specified stream may be inaccurate or incomplete. This message serves as an indicator to implement necessary measures for data integrity (e.g. "do a full refresh"). 