### PR TITLE
docs: Explain why recordCount is a number instead of an integer

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -196,7 +196,7 @@ definitions:
     additionalProperties: true
     properties:
       recordCount:
-        description: "the number of records which were emitted for this state message, for this stream or global"
+        description: "the number of records which were emitted for this state message, for this stream or global. While the value should always be a round number, it is defined as a double to account for integer overflows, and the value should always have a decimal point for proper serialization."
         type: number
   AirbyteLogMessage:
     type: object


### PR DESCRIPTION
Explain why recordCount is a number instead of an integer