### PR TITLE
feat(python): add support for Pydantic v2 forward-compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ data
 **/gmon.out
 static_checker_reports/
 
+# Don't commit auto-generated Python code files:
+/protocol-models/python/airbyte_protocol/models
+
 # Python
 *.egg-info
 __pycache__

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing Guide
+
+## Contributing to the Python library
+
+You can test Python library generation by running the following command:
+
+```bash
+./airbyte-protocol/bin/generate-python-classes.sh
+```
+
+File will be generated in `airbyte-protocol/airbyte_protocol/models/...`.
+
+These generated files are ignored by git.

--- a/protocol-models/bin/generate-python-classes.sh
+++ b/protocol-models/bin/generate-python-classes.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+#
+# This script uses datamodel-codegen to generate Python classes from the OpenAPI schema files in the
+# protocol-models directory.
+#
+# Docs are here: https://koxudaxi.github.io/datamodel-code-generator
+#
+# The tool can generate classes for different Python libraries.
+# We use pydantic.BaseModel (v1).
 
 set -e
 
@@ -14,7 +22,7 @@ YAML_DIR=protocol-models/src/main/resources/airbyte_protocol
 OUTPUT_DIR=protocol-models/python/airbyte_protocol/models
 
 python -m pip install --upgrade pip
-pip install datamodel_code_generator==0.11.19
+pip install datamodel_code_generator==0.25.6
 
 rm -rf "$ROOT_DIR/$OUTPUT_DIR"/*.py
 mkdir -p "$ROOT_DIR/$OUTPUT_DIR"
@@ -30,5 +38,10 @@ for f in "$ROOT_DIR/$YAML_DIR"/*.yaml; do
     --input "$ROOT_DIR/$YAML_DIR/$filename_wo_ext.yaml" \
     --output "$ROOT_DIR/$OUTPUT_DIR/$filename_wo_ext.py" \
     --use-title-as-name \
-    --disable-timestamp
+    --disable-timestamp \
+    --input-file-type jsonschema \
+    --output-model-type pydantic.BaseModel \
+    --base-class "..BaseModel_v1" \
+    --custom-file-header-path "protocol-models/python/generation-file-header.py" \
+    --target-python-version 3.7
 done

--- a/protocol-models/python/generation-file-header.py
+++ b/protocol-models/python/generation-file-header.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+"""Auto-generated code file. Do not modify."""
+
+# We use Pydantic 1.x for backwards compatibility. We import it in a
+# way that is also forwards compatible with Pydantic 2.x.
+try:
+    import pydantic.v1 import BaseModel as BaseModel_v1
+    # If this succeeds we are using Pydantic 2.x, but we import the backwards-compatible
+    # version of BaseModel.
+except ImportError:
+    # In this case, we are using Pydantic 1.x and we import as usual.
+    import pydantic import BaseModel as BaseModel_v1

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,9 @@ Declares the Airbyte Protocol.
 * `airbyte_protocol.yaml` - declares the Airbyte Protocol (in JSONSchema)
 * `io.airbyte.protocol.models` - this package contains various java helpers for working with the protocol.
 
+## Contributing
+
+For more information on how to contribute to this repository, please see the [contributing guide](./CONTRIBUTING.md).
 
 ## Pull Requests Titles Must Conform to Conventional Commits Convention
 We are leveraging the [Release Please Action](https://github.com/marketplace/actions/release-please-action) to manage our version bumping and releasing.


### PR DESCRIPTION
Resolves: #76 

- #76 

This PR makes the Pydantic implementation forwards-compatible for Pydantic 2.x.