### PR TITLE
feat: Add overwrite_dedup destination sync mode

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -524,14 +524,14 @@ definitions:
           items:
             type: string
       generation_id:
-        description: 
+        description:
           "Monotically increasing numeric id representing the current generation of a stream. This id can be shared across syncs.
 
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
       minimum_generation_id:
-        description: 
+        description:
           "The minimum generation id which is needed in a stream. If it is present, the destination will try to delete the data that are part of a generation lower than this property.
           If the minimum generation is equals to 0, no data deletion is expected from the destiantion
 
@@ -539,7 +539,7 @@ definitions:
           "
         type: integer
       sync_id:
-        description: 
+        description:
           "Monotically increasing numeric id representing the current sync id. This is aimed to be unique per sync.
 
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
@@ -557,6 +557,7 @@ definitions:
       - overwrite
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
+      - overwrite_dedup # thanks, resumable full refresh
   ConnectorSpecification:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -525,24 +525,24 @@ definitions:
           items:
             type: string
       generation_id:
-        description: 
+        description:
           "Monotically increasing numeric id representing the current generation of a stream. This id can be shared across syncs.
 
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
       minimum_generation_id:
-        description: 
+        description:
           "The minimum generation id which is needed in a stream. If it is present, the destination will try to delete the data that are part of a generation lower than this property.
           If the minimum generation is equals to 0, no data deletion is expected from the destiantion
-        
+
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
       sync_id:
-        description: 
+        description:
           "Monotically increasing numeric id representing the current sync id. This is aimed to be unique per sync.
-        
+
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
@@ -558,6 +558,7 @@ definitions:
       - overwrite
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
+      - overwrite_dedup # thanks, resumable full refresh
   OAuth2Specification:
     type: object
     additionalProperties: true


### PR DESCRIPTION
Things that this protocol change implies:
* Destinations that support Overwrite+Dedupe will need to update their SPECs
* The platform models which do not rely on the protocol directly will need to update to include this new option

Open Questions:

* Is there an ENUM in the database that needs to be updated?
* Where in the platform (or UI code?) do we validate that the source stream has a PK and cursor before allowing Dedupe to be selected?  Do we need to update anything there?
