### PR TITLE
Add platform mapper error to meta changes reasons.

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -120,6 +120,7 @@ definitions:
           - PLATFORM_SERIALIZATION_ERROR
           # Errors producing the field
           - SOURCE_RETRIEVAL_ERROR
+          - PLATFORM_MAPPER_ERROR
           # Errors casting to appropriate type
           - DESTINATION_TYPECAST_ERROR
   AirbyteStateMessage:


### PR DESCRIPTION
Add `PLATFORM_MAPPER_ERROR` to MetaChanges reasons to track fields being nulled or truncated due to an error during the mapping.