### PR TITLE
fix: fix build issues with plugin versions not compatible with java 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ subprojects { subproj ->
     }
 
     jacoco {
-        toolVersion = "0.8.8"
+        toolVersion = "0.8.12"
     }
 
     jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 plugins {
     id 'base'
     id 'pmd'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id 'com.diffplug.spotless' version '6.21.0'
     id 'com.github.hierynomus.license' version '0.16.1'
     id 'com.github.spotbugs' version '5.0.13'
     // The distribution plugin has been added to address the an issue with the copyGeneratedTar

--- a/build.gradle
+++ b/build.gradle
@@ -243,7 +243,7 @@ subprojects { subproj ->
         excludeFilter = rootProject.file('spotbugs-exclude-filter-file.xml')
         reportLevel = 'high'
         showProgress = false
-        toolVersion = '4.7.3'
+        toolVersion = '4.8.2'
     }
 
     test {

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -3,7 +3,7 @@
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/v1/airbyte_protocol.yaml
 title: AirbyteProtocol
 type: object
-description: AirbyteProtocol structs dummy change
+description: AirbyteProtocol structs
 version: 1.0.0
 properties:
   airbyte_message:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -3,7 +3,7 @@
 "$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/models/src/main/resources/airbyte_protocol/v1/airbyte_protocol.yaml
 title: AirbyteProtocol
 type: object
-description: AirbyteProtocol structs
+description: AirbyteProtocol structs dummy change
 version: 1.0.0
 properties:
   airbyte_message:


### PR DESCRIPTION
After [updating our java and gradle versions](https://github.com/airbytehq/airbyte-protocol/pull/97), code compiles, but does not build due to various things we run during the build like `spotBugs` and `spotless` erroring out. This updates the dependencies to java 21 - compatible versions.