### PR TITLE
ci: always run build + publish artifacts on pull requests

### DIFF
--- a/.github/workflows/pull-request-publish.yml
+++ b/.github/workflows/pull-request-publish.yml
@@ -10,8 +10,6 @@ on:
     types:
       - opened
       - synchronize
-    paths:
-      - "protocol-models/**"
 
 jobs:
   pull-request-publish:


### PR DESCRIPTION
some changes outside of the `"protocol-models/**"` paths affect our ability to build + run code. Run this step on all PRs so that we can block merging if the java build or the generation into other languages fails. 