### PR TITLE
feat: (airbyte-protocol) add new record message type

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -122,6 +122,31 @@ definitions:
           - SOURCE_RETRIEVAL_ERROR
           # Errors casting to appropriate type
           - DESTINATION_TYPECAST_ERROR
+  AirbyteFileTransferRecordMessage:
+    type: object
+    additionalProperties: true
+    required:
+      - stream
+      - file
+      - emitted_at
+    properties:
+      namespace:
+        description: "namespace the data is associated with"
+        type: string
+      stream:
+        description: "stream the data is associated with"
+        type: string
+      file:
+        description: "transfer file data"
+        type: object
+        existingJavaType: com.fasterxml.jackson.databind.JsonNode
+      data:
+        description: "record data"
+        type: object
+        existingJavaType: com.fasterxml.jackson.databind.JsonNode
+      emitted_at:
+        description: "when the data was emitted from the source. epoch in millisecond."
+        type: integer
   AirbyteStateMessage:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -122,7 +122,7 @@ definitions:
           - SOURCE_RETRIEVAL_ERROR
           # Errors casting to appropriate type
           - DESTINATION_TYPECAST_ERROR
-  AirbyteFileTransferRecordMessage:
+  AirbyteFileTransferMessage:
     type: object
     additionalProperties: true
     required:
@@ -137,13 +137,7 @@ definitions:
         description: "stream the data is associated with"
         type: string
       file:
-        description: "transfer file data"
-        type: object
-        existingJavaType: com.fasterxml.jackson.databind.JsonNode
-      data:
-        description: "record data"
-        type: object
-        existingJavaType: com.fasterxml.jackson.databind.JsonNode
+        "$ref": "#/definitions/AirbyteFileType"
       emitted_at:
         description: "when the data was emitted from the source. epoch in millisecond."
         type: integer
@@ -201,6 +195,30 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/AirbyteStreamState"
+  AirbyteFileType:
+    type: object
+    additionalProperties: true
+    required:
+      - file_url
+      - file_relative_path
+      - modified
+      - bytes
+    properties:
+      file_url:
+        description: "local path to file"
+        type: string
+      file_relative_path:
+        description: "relative path to file"
+        type: string
+      source_file_url:
+        description: "source file path"
+        type: string
+      modified:
+        description: "file modified date. epoch in millisecond"
+        type: string
+      bytes:
+        description: "file size in bytes"
+        type: integer
   StreamDescriptor:
     type: object
     additionalProperties: true


### PR DESCRIPTION
## Context
To be competitive with very large data volumes, we have no other option than to add file-based bulk data transfers.

![image](https://github.com/user-attachments/assets/761973ee-c39e-4868-a727-bb891df54a6e)


## How
Through the CDK, we will leverage the file-based connector's ability to write a file locally instead of sending records and emit a new record message with metadata related to the file.

```
{
  "type": "RECORD",
  "record": {
    "stream": "simpsons_locations",
    "file": {
      "file_url": "/tmp/airbyte-file-transfer/sftp-testing-for-file-transfer/sftp-folder/simpsons_locations.csv",
      "bytes": 182776,
      "file_relative_path": "sftp-testing-for-file-transfer/sftp-folder/simpsons_locations.csv",
      "modified": 1728330963000,
      "source_file_url": "//sftp-testing-for-file-transfer/sftp-folder/simpsons_locations.csv"
    },
    "emitted_at": 1730226374632,
    "data": {}
  }
}
```

Now we want to formerly move [this message in the cdk](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/models/file_transfer_record_message.py) to airbyte protocol.

[Here](https://docs.google.com/document/d/1hHJs1KMvlLO-pXH_EJi0gpUPV1c4G4MwWmXx5P0NipQ/edit?tab=t.0#bookmark=id.hjnmmbn159qi), you can find a ref to the documentation of the project.

## How would be used in python (CDK)?

Initially, this should replace [this file](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/models/file_transfer_record_message.py) so we don't import [this](https://github.com/airbytehq/airbyte-python-cdk/blob/310d26db570215409a5d1901253b06d09d9af965/airbyte_cdk/models/airbyte_protocol.py#L8) but get from protocol library in [this other import](https://github.com/airbytehq/airbyte-python-cdk/blob/310d26db570215409a5d1901253b06d09d9af965/airbyte_cdk/models/airbyte_protocol.py#L9). Now, final implementation could require more work if we decide to change keys naming and structure.

Also, we could change [this dataclass](https://github.com/airbytehq/airbyte-python-cdk/blob/310d26db570215409a5d1901253b06d09d9af965/airbyte_cdk/models/airbyte_protocol.py#L86) to have a new file key rather than threat as another record class.


### Note: 
We agree to wait a little bit [here](https://airbytehq-team.slack.com/archives/C07J0JYAL13/p1731443777349329), but it's nice to have some point to start talking about for future change, so there's no rush on this.