### PR TITLE
fix: (DeclarativeOAuthFlow) - add `access_token_params` property to match the actual spec properties

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -739,22 +739,23 @@ definitions:
                 }
           state:
             type: object
-            additionalProperties: true
             description: |-
               The OAuth Specific object to provide the criteria of how the `state` query param should be constructed,
               including length and complexity.
 
-              TODO: review and edit this property, once the state generation logic is finilized.
-
               Examples:
                 {
                   "state": {
-                    "min_length": 7,
-                    "max_length": 128,
-                    "min_special": 3,
-                    "excluded": ["$", "\\", "."]
+                    "min": 7,
+                    "max": 128,
                   }
                 }
+            additionalProperties: true
+            properties:
+              min:
+                type: integer
+              max:
+                type: integer
           client_id_key:
             type: string
             description: |-

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -659,10 +659,9 @@ definitions:
         description: |-
           OAuth specific blob. Pertains to the fields defined by the connector relating to the OAuth flow.
         type: object
-        additionalProperties: false
+        additionalProperties: true
         required: 
           - consent_url
-          - scope
           - access_token_url
           - extract_output
         properties:
@@ -708,6 +707,20 @@ definitions:
                 {
                   "access_token_headers": {
                       "Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"
+                  }
+                }
+          access_token_params:
+            type: object
+            additionalProperties: true
+            description: |-
+              The OAuth Specific optional query parameters to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.
+              When this property is provided, the query params are encoded as `Json string` and passed to the outgoing API request.
+
+              Examples:
+                {
+                  "access_token_params": {
+                      "my_query_param": "param_value",
+                      "{client_id_key}": {{client_id_key}}
                   }
                 }
           extract_output:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -714,10 +714,9 @@ definitions:
         description: |-
           OAuth specific blob. Pertains to the fields defined by the connector relating to the OAuth flow.
         type: object
-        additionalProperties: false
+        additionalProperties: true
         required: 
           - consent_url
-          - scope
           - access_token_url
           - extract_output
         properties:
@@ -763,6 +762,20 @@ definitions:
                 {
                   "access_token_headers": {
                       "Authorization": "Basic {base64Encoder:{client_id}:{client_secret}}"
+                  }
+                }
+          access_token_params:
+            type: object
+            additionalProperties: true
+            description: |-
+              The OAuth Specific optional query parameters to inject while exchanging the `auth_code` to `access_token` during `completeOAuthFlow` step.
+              When this property is provided, the query params are encoded as `Json string` and passed to the outgoing API request.
+
+              Examples:
+                {
+                  "access_token_params": {
+                      "my_query_param": "param_value",
+                      "{client_id_key}": {{client_id_key}}
                   }
                 }
           extract_output:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -794,22 +794,23 @@ definitions:
                 }
           state:
             type: object
-            additionalProperties: true
             description: |-
               The OAuth Specific object to provide the criteria of how the `state` query param should be constructed,
               including length and complexity.
 
-              TODO: review and edit this property, once the state generation logic is finilized.
-
               Examples:
                 {
                   "state": {
-                    "min_length": 7,
-                    "max_length": 128,
-                    "min_special": 3,
-                    "excluded": ["$", "\\", "."]
+                    "min": 7,
+                    "max": 128,
                   }
                 }
+            additionalProperties: true
+            properties:
+              min:
+                type: integer
+              max:
+                type: integer
           client_id_key:
             type: string
             description: |-


### PR DESCRIPTION
## What
While working on the migration for `TikTok Marketing` OAuthFlow, there was a need to encode the `access_token_url` query parameters to `json string` instead of `url_encoded` parameters. 

The `access_token_params` is there to provide such a functionality, in order to match the actual spec provided with the designed `protocol` DeclarativeOAuth spec this property should exist at the `protocol` level.

## How
- add the `access_token_params` object property to the `OAuthConfigSpecification.oauth_connector_input_specification.properties`
- made the `additionalProperties` set to `true` to allow future lazy spec improvements, even though the protocol could be behind of the actual source / destination spec, allowing us to provide more properties to work with.
