### PR TITLE
ci: fix pydantic v2 model gen by explicitly mark input files as jsonschema

### DIFF
--- a/protocol-models/bin/generate-python-dataclasses.sh
+++ b/protocol-models/bin/generate-python-dataclasses.sh
@@ -27,6 +27,7 @@ for f in "$ROOT_DIR/$YAML_DIR"/*.yaml; do
   echo "from .$filename_wo_ext import *" >> "$ROOT_DIR/$OUTPUT_DIR"/__init__.py
 
   datamodel-codegen \
+    --input-file-type jsonschema \
     --input "$ROOT_DIR/$YAML_DIR/$filename_wo_ext.yaml" \
     --output "$ROOT_DIR/$OUTPUT_DIR/$filename_wo_ext.py" \
     --output-model-type dataclasses.dataclass \

--- a/protocol-models/bin/generate-python-pydantic-v2.sh
+++ b/protocol-models/bin/generate-python-pydantic-v2.sh
@@ -27,6 +27,7 @@ for f in "$ROOT_DIR/$YAML_DIR"/*.yaml; do
   echo "from .$filename_wo_ext import *" >> "$ROOT_DIR/$OUTPUT_DIR"/__init__.py
 
   datamodel-codegen \
+    --input-file-type jsonschema \
     --input "$ROOT_DIR/$YAML_DIR/$filename_wo_ext.yaml" \
     --output "$ROOT_DIR/$OUTPUT_DIR/$filename_wo_ext.py" \
     --output-model-type pydantic_v2.BaseModel \


### PR DESCRIPTION
## Problem
Some dependency changed in the background on our build pipeline causing our `jsonschema` files to be interpretted as `json` and breaking our release ci for both main and individual branches.

Discovered in #106 

## Solution
Explicitly mark inout files as jsonschema