### PR TITLE
RFC: Branch for Files + Metadata spike protocol changes

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # x-release-please-start-version
-VERSION=0.14.2
+VERSION=0.14.3-SNAPSHOT
 # x-release-please-end

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # x-release-please-start-version
-VERSION=0.14.3-SNAPSHOT
+VERSION=0.14.1337
 # x-release-please-end

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # x-release-please-start-version
-VERSION=0.14.3
+VERSION=0.14.1337
 # x-release-please-end

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # x-release-please-start-version
-VERSION=0.14.1337
+VERSION=0.14.3
 # x-release-please-end

--- a/.github/workflows/pull-request-publish.yml
+++ b/.github/workflows/pull-request-publish.yml
@@ -49,6 +49,7 @@ jobs:
           # will use the version in .env
         run: |
           cat .env
+          echo VERSION: $VERSION
           ./gradlew publish
 
       # python

--- a/.github/workflows/pull-request-publish.yml
+++ b/.github/workflows/pull-request-publish.yml
@@ -47,7 +47,9 @@ jobs:
           CLOUDREPO_USER: ${{ secrets.CLOUDREPO_USER }}
           CLOUDREPO_PASSWORD: ${{ secrets.CLOUDREPO_PASSWORD }}
           # will use the version in .env
-        run: ./gradlew publish
+        run: |
+          cat .env
+          ./gradlew publish
 
       # python
       - name: Generate Python Protocol Classes

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -129,10 +129,14 @@ definitions:
     type: object
     additionalProperties: true
     properties:
-      local_path:
+      file_url:
         type: string
         description: |-
-          The path to the referenced file on the local shared volume.
+          The absolute path to the referenced file.
+      file_relative_path:
+        type: string
+        description: |-
+          The relative path to the referenced file in source.
       file_size_bytes:
         type: integer
         description: |-

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -76,7 +76,7 @@ definitions:
       meta:
         description: Information about this record added mid-sync
         "$ref": "#/definitions/AirbyteRecordMessageMeta"
-      fileReference:
+      file_reference:
         description: A reference to assoicated file to be moved with along with the record data.
         "$ref": "#/definitions/AirbyteRecordMessageFileReference"
   AirbyteRecordMessageMeta:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -76,6 +76,9 @@ definitions:
       meta:
         description: Information about this record added mid-sync
         "$ref": "#/definitions/AirbyteRecordMessageMeta"
+      fileData:
+        description: Information about any assoicated files moved with along with the record data.
+        "$ref": "#/definitions/AirbyteRecordMessageFileData"
   AirbyteRecordMessageMeta:
     type: object
     additionalProperties: true
@@ -122,6 +125,18 @@ definitions:
           - SOURCE_RETRIEVAL_ERROR
           # Errors casting to appropriate type
           - DESTINATION_TYPECAST_ERROR
+  AirbyteRecordMessageFileData:
+    type: object
+    additionalProperties: true
+    properties:
+      local_path:
+        type: string
+        description: |-
+          The path to the referenced file on the local shared volume.
+      file_size_bytes:
+        type: integer
+        description: |-
+          The size of the referenced file in bytes.
   AirbyteStateMessage:
     type: object
     additionalProperties: true
@@ -484,6 +499,10 @@ definitions:
           If the stream is resumable or not. Should be set to true if the stream supports incremental. Defaults to false.
           Primarily used by the Platform in Full Refresh to determine if a Full Refresh stream should actually be treated as incremental within a job.
         type: boolean
+      is_file_based:
+        type: boolean
+        description: |-
+          This stream represents a series of discrete files and their metadata.
   ConfiguredAirbyteCatalog:
     type: object
     additionalProperties: true
@@ -545,6 +564,10 @@ definitions:
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
+      copy_associated_file:
+        type: boolean
+        description: |-
+          If the stream is_file_based, the associated file will be copied to local disk and passed via reference along with its metadata.
   SyncMode:
     type: string
     enum:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -76,9 +76,9 @@ definitions:
       meta:
         description: Information about this record added mid-sync
         "$ref": "#/definitions/AirbyteRecordMessageMeta"
-      fileData:
-        description: Information about any assoicated files moved with along with the record data.
-        "$ref": "#/definitions/AirbyteRecordMessageFileData"
+      fileReference:
+        description: A reference to assoicated file to be moved with along with the record data.
+        "$ref": "#/definitions/AirbyteRecordMessageFileReference"
   AirbyteRecordMessageMeta:
     type: object
     additionalProperties: true
@@ -125,7 +125,7 @@ definitions:
           - SOURCE_RETRIEVAL_ERROR
           # Errors casting to appropriate type
           - DESTINATION_TYPECAST_ERROR
-  AirbyteRecordMessageFileData:
+  AirbyteRecordMessageFileReference:
     type: object
     additionalProperties: true
     properties:


### PR DESCRIPTION
## What
1) Adds properties to `AirbyteStream` and `ConfiguredAirbyteStream` to describe whether a stream is file based and whether any associated files should be copied

2) Adds `AirbyteRecordMessageFileRefrence` struct to be included as optional field `fileReference` to `AirybteRecordMessage` for passing through copied file reference to the destination

Unblocks further spike work.

## Next steps
Once agreed upon we can publish a "fake" version and the teams can start hacking