### PR TITLE
fix: use .env file with Gradle

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -21,6 +21,12 @@ runs:
         distribution: "zulu"
         java-version: "21"
 
+    - name: Load .env file
+      uses: xom9ikk/dotenv@v2.3.0
+      with:
+        path: ./
+        load-mode: strict
+
     # java
     - name: Gradle Build
       shell: bash

--- a/.github/workflows/pull-request-publish.yml
+++ b/.github/workflows/pull-request-publish.yml
@@ -38,6 +38,12 @@ jobs:
           sed -i -e "s/$CURRENT_VERSION/$CURRENT_VERSION.dev$(date +%s)/g" .env
           cat .env
 
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2.3.0
+        with:
+          path: ./
+          load-mode: strict
+
       # java
       - name: Gradle Build
         run: ./gradlew build --scan

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
-import java.util.Properties
+/*
+ * Copyright (c) 2020-2025 Airbyte, Inc., all rights reserved.
+ */
 
 // The buildscript block defines dependencies in order for .gradle file evaluation.
 // This is separate from application dependencies.
@@ -35,14 +37,7 @@ repositories {
     }
 }
 
-val env = Properties()
-rootProject.file(".env").inputStream().use {
-    env.load(it)
-}
-
 allprojects {
     apply(plugin = "base")
-
     group = "io.airbyte.${rootProject.name}"
-    version = System.getenv("VERSION") ?: env["VERSION"].toString()
 }

--- a/protocol-models/build.gradle.kts
+++ b/protocol-models/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2020-2025 Airbyte, Inc., all rights reserved.
+ */
+
 import org.jsonschema2pojo.SourceType
 
 plugins {
@@ -33,6 +37,9 @@ jsonSchema2Pojo {
     includeSetters = true
     serializable = true
 }
+
+project.logger.lifecycle("Group = $group")
+project.logger.lifecycle("Group = ${project.group}")
 
 tasks.register<Exec>("generatePythonPydanticV1ClassFiles") {
     inputs.dir("${sourceSets["main"].output.resourcesDir}/airbyte_protocol")

--- a/protocol-models/build.gradle.kts
+++ b/protocol-models/build.gradle.kts
@@ -38,9 +38,6 @@ jsonSchema2Pojo {
     serializable = true
 }
 
-project.logger.lifecycle("Group = $group")
-project.logger.lifecycle("Group = ${project.group}")
-
 tasks.register<Exec>("generatePythonPydanticV1ClassFiles") {
     inputs.dir("${sourceSets["main"].output.resourcesDir}/airbyte_protocol")
     inputs.dir("bin")


### PR DESCRIPTION
Fixes publishing of the JAR portion of the airbyte-protocol protocol-models library:

* Modify GitHub action to load `VERSION` env var from .env file
* Use logic from `AirbyteJvmPlugin` that sets the project's version based on the `VERSION` env var

I tested this locally by running the publishing task with and without the `VERSION` env var set.

Without:

> https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/io/airbyte/airbyte-protocol/protocol-models/dev/protocol-models-dev.jar

The `dev` version comes from the `AirbyteJvmPlugin`, which defaults to `dev` if the `VERSION` env var is not set:  `version = System.getenv("VERSION") ?: "dev"`

With:

> export VERSION=someversion
> https://airbyte.mycloudrepo.io/repositories/airbyte-public-jars/io/airbyte/airbyte-protocol/protocol-models/someversion/protocol-models-someversion.jar

I don't believe that the CI action changes will take effect in this PR, so we would need to open another PR to test it out fully.
