### PR TITLE
chore: equalise V0 and V1 protocol definitions.

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -557,6 +557,7 @@ definitions:
       - overwrite
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
+  # Deprecated
   OAuth2Specification:
     type: object
     additionalProperties: true

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -293,7 +293,7 @@ definitions:
           Estimates are either per-stream (STREAM) or for the entire sync (SYNC).
           STREAM is preferred, and requires the source to count how many records are about to be emitted per-stream (e.g. there will be 100 rows from this table emitted).
           For the rare source which cannot tell which stream a record belongs to before reading (e.g. CDC databases), SYNC estimates can be emitted.
-          Sources should not emit both STREAM and SOURCE estimates within a sync.
+          Sources should not emit both STREAM and SYNC estimates within a sync.
         type: string
         enum:
           - STREAM
@@ -557,6 +557,50 @@ definitions:
       - overwrite
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
+  OAuth2Specification:
+    type: object
+    additionalProperties: true
+    description: An object containing any metadata needed to describe this connector's Oauth flow. Deprecated, switching to advanced_auth instead
+    properties:
+      rootObject:
+        description:
+          "A list of strings representing a pointer to the root object which contains any oauth parameters in the ConnectorSpecification.
+          Examples:
+          if oauth parameters were contained inside the top level, rootObject=[]
+          If they were nested inside another object {'credentials': {'app_id' etc...}, rootObject=['credentials']
+          If they were inside a oneOf {'switch': {oneOf: [{client_id...}, {non_oauth_param]}},  rootObject=['switch', 0]
+          "
+        type: array
+        items:
+          oneOf:
+            - type: string
+            - type: integer
+
+      oauthFlowInitParameters:
+        description:
+          "Pointers to the fields in the rootObject needed to obtain the initial refresh/access tokens for the OAuth flow.
+          Each inner array represents the path in the rootObject of the referenced field.
+          For example.
+          Assume the rootObject contains params 'app_secret', 'app_id' which are needed to get the initial refresh token.
+          If they are not nested in the rootObject, then the array would look like this [['app_secret'], ['app_id']]
+          If they are nested inside an object called 'auth_params' then this array would be [['auth_params', 'app_secret'], ['auth_params', 'app_id']]"
+        type: array
+        items:
+          description: A list of strings denoting a pointer into the rootObject for where to find this property
+          type: array
+          items:
+            type: string
+      oauthFlowOutputParameters:
+        description:
+          "Pointers to the fields in the rootObject which can be populated from successfully completing the oauth flow using the init parameters.
+          This is typically a refresh/access token.
+          Each inner array represents the path in the rootObject of the referenced field."
+        type: array
+        items:
+          description: A list of strings denoting a pointer into the rootObject for where to find this property
+          type: array
+          items:
+            type: string
   ConnectorSpecification:
     type: object
     additionalProperties: true
@@ -599,6 +643,16 @@ definitions:
         type: array
         items:
           "$ref": "#/definitions/DestinationSyncMode"
+      authSpecification:
+        description: deprecated, switching to advanced_auth instead
+        type: object
+        properties:
+          auth_type:
+            type: string
+            enum: [ "oauth2.0" ] # Future auth types should be added here
+          oauth2Specification:
+            description: If the connector supports OAuth, this field should be non-null.
+            "$ref": "#/definitions/OAuth2Specification"
       advanced_auth:
         description: |-
           Additional and optional specification object to describe what an 'advanced' Auth flow would need to function.

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -122,7 +122,8 @@ definitions:
           - PLATFORM_SERIALIZATION_ERROR
           # Errors producing the field
           - SOURCE_RETRIEVAL_ERROR
-
+          # Errors casting to appropriate type
+          - DESTINATION_TYPECAST_ERROR
   AirbyteStateMessage:
     type: object
     additionalProperties: true
@@ -197,7 +198,7 @@ definitions:
     additionalProperties: true
     properties:
       recordCount:
-        description: "the number of records which were emitted for this state message, for this stream or global"
+        description: "the number of records which were emitted for this state message, for this stream or global. While the value should always be a round number, it is defined as a double to account for integer overflows, and the value should always have a decimal point for proper serialization."
         type: number
   AirbyteLogMessage:
     type: object


### PR DESCRIPTION
Today we define and publish V1 along side V0. This is a remnant from the V1 breaking change a few years back that we are no longer doing.

Unfortunately this means we now have **different components using both V1 and V0 code packages**. It's also easy for us to accidentally update one file and not the other - **drift exists today**. All of this is confusing.

I want to remove V1 from the protocol repo and move everyone over to V0. We'll reintroduce V1 when we are properly migrating. Step 1 is equalising both files.