### PR TITLE
feat: add support for file+metadata streams

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # x-release-please-start-version
-VERSION=0.15.0
+VERSION=0.14.5
 # x-release-please-end

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # x-release-please-start-version
-VERSION=0.14.5
+VERSION=0.15.0
 # x-release-please-end

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -503,10 +503,10 @@ definitions:
           If the stream is resumable or not. Should be set to true if the stream supports incremental. Defaults to false.
           Primarily used by the Platform in Full Refresh to determine if a Full Refresh stream should actually be treated as incremental within a job.
         type: boolean
-      has_file_attachments:
+      is_file_based:
         type: boolean
         description: |-
-          This stream references file attachments that can be optionally moved.
+          This stream describes a stream of files and their metadata.
   ConfiguredAirbyteCatalog:
     type: object
     additionalProperties: true
@@ -568,10 +568,10 @@ definitions:
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
-      include_file_attachments:
+      include_files:
         type: boolean
         description: |-
-          If the stream has_file_attachments, determines whether to include the associated files in the sync.
+          If the stream is_file_based, determines whether to include the associated files in the sync.
   SyncMode:
     type: string
     enum:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -76,6 +76,9 @@ definitions:
       meta:
         description: Information about this record added mid-sync
         "$ref": "#/definitions/AirbyteRecordMessageMeta"
+      file_reference:
+        description: An internal facing reference to the file described by the record if applicable.
+        "$ref": "#/definitions/AirbyteRecordMessageFileReference"
   AirbyteRecordMessageMeta:
     type: object
     additionalProperties: true
@@ -122,6 +125,22 @@ definitions:
           - SOURCE_RETRIEVAL_ERROR
           # Errors casting to appropriate type
           - DESTINATION_TYPECAST_ERROR
+  AirbyteRecordMessageFileReference:
+    type: object
+    additionalProperties: true
+    properties:
+      staging_file_url:
+        type: string
+        description: |-
+          The absolute path to the referenced file in the staging area.
+      file_relative_path:
+        type: string
+        description: |-
+          The relative path to the referenced file in source.
+      file_size_bytes:
+        type: integer
+        description: |-
+          The size of the referenced file in bytes.
   AirbyteStateMessage:
     type: object
     additionalProperties: true
@@ -484,6 +503,10 @@ definitions:
           If the stream is resumable or not. Should be set to true if the stream supports incremental. Defaults to false.
           Primarily used by the Platform in Full Refresh to determine if a Full Refresh stream should actually be treated as incremental within a job.
         type: boolean
+      has_file_attachments:
+        type: boolean
+        description: |-
+          This stream references file attachments that can be optionally moved.
   ConfiguredAirbyteCatalog:
     type: object
     additionalProperties: true
@@ -545,6 +568,10 @@ definitions:
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
+      include_file_attachments:
+        type: boolean
+        description: |-
+          If the stream has_file_attachments, determines whether to include the associated files in the sync.
   SyncMode:
     type: string
     enum:

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -133,7 +133,7 @@ definitions:
         type: string
         description: |-
           The absolute path to the referenced file in the staging area.
-      file_relative_path:
+      source_file_relative_path:
         type: string
         description: |-
           The relative path to the referenced file in source.

--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -571,7 +571,7 @@ definitions:
       include_files:
         type: boolean
         description: |-
-          If the stream is_file_based, determines whether to include the associated files in the sync.
+          If the stream is_file_based, determines whether to include the associated files in the sync. Otherwise, this property will be ignored.
   SyncMode:
     type: string
     enum:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -574,7 +574,7 @@ definitions:
       include_files:
         type: boolean
         description: |-
-          If the stream is_file_based, determines whether to include the associated files in the sync.
+          If the stream is_file_based, determines whether to include the associated files in the sync. Otherwise, this property will be ignored.
   SyncMode:
     type: string
     enum:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -506,10 +506,10 @@ definitions:
           If the stream is resumable or not. Should be set to true if the stream supports incremental. Defaults to false.
           Primarily used by the Platform in Full Refresh to determine if a Full Refresh stream should actually be treated as incremental within a job.
         type: boolean
-      has_file_attachments:
+      is_file_based:
         type: boolean
         description: |-
-          This stream references file attachments that can be optionally moved.
+          This stream describes a stream of files and their metadata.
   ConfiguredAirbyteCatalog:
     type: object
     additionalProperties: true
@@ -571,10 +571,10 @@ definitions:
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
-      include_file_attachments:
+      include_files:
         type: boolean
         description: |-
-          If the stream has_file_attachments, determines whether to include the associated files in the sync.
+          If the stream is_file_based, determines whether to include the associated files in the sync.
   SyncMode:
     type: string
     enum:

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -135,7 +135,7 @@ definitions:
         type: string
         description: |-
           The absolute path to the referenced file in the staging area.
-      file_relative_path:
+      source_file_relative_path:
         type: string
         description: |-
           The relative path to the referenced file in source.

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -76,6 +76,9 @@ definitions:
       meta:
         description: Information about this record added mid-sync
         "$ref": "#/definitions/AirbyteRecordMessageMeta"
+      file_reference:
+        description: An internal facing reference to the file described by the record if applicable.
+        "$ref": "#/definitions/AirbyteRecordMessageFileReference"
 
   AirbyteRecordMessageMeta:
     type: object
@@ -124,6 +127,23 @@ definitions:
           - SOURCE_RETRIEVAL_ERROR
           # Errors casting to appropriate type
           - DESTINATION_TYPECAST_ERROR
+  AirbyteRecordMessageFileReference:
+    type: object
+    additionalProperties: true
+    properties:
+      staging_file_url:
+        type: string
+        description: |-
+          The absolute path to the referenced file in the staging area.
+      file_relative_path:
+        type: string
+        description: |-
+          The relative path to the referenced file in source.
+      file_size_bytes:
+        type: integer
+        description: |-
+          The size of the referenced file in bytes.
+
   AirbyteStateMessage:
     type: object
     additionalProperties: true
@@ -486,6 +506,10 @@ definitions:
           If the stream is resumable or not. Should be set to true if the stream supports incremental. Defaults to false.
           Primarily used by the Platform in Full Refresh to determine if a Full Refresh stream should actually be treated as incremental within a job.
         type: boolean
+      has_file_attachments:
+        type: boolean
+        description: |-
+          This stream references file attachments that can be optionally moved.
   ConfiguredAirbyteCatalog:
     type: object
     additionalProperties: true
@@ -547,6 +571,10 @@ definitions:
           If this is null, it means that the platform is not supporting the refresh and it is expected that no extra id will be added to the records and no data from previous generation will be cleanup.
           "
         type: integer
+      include_file_attachments:
+        type: boolean
+        description: |-
+          If the stream has_file_attachments, determines whether to include the associated files in the sync.
   SyncMode:
     type: string
     enum:


### PR DESCRIPTION
## What
Adds support for "file based" streams — streams consisting of files _and_ their associated metadata. 

These streams may be synced alongside normal streams, enabling a single connection to support both files and records.

Detailed information explaining the motivations of the supported feature and the changes themselves can be found in the proposal doc linked below.

## Links
[Protocol Proposal Doc](https://docs.google.com/document/d/1SaGZEMXTku6IC3MWWTvzK_bWtJr1vcP7I3mRHPVH-Tc/edit?tab=t.0)

[Feature description](https://docs.google.com/document/d/1CFPWkHD2cfJ9cHpqI-T3G6z7qjWFWUepA0d6cl9LZkY/edit?tab=t.0#heading=h.ka3phxnzyvn4)

Evolution of [spike draft](https://github.com/airbytehq/airbyte-protocol/pull/111)
