### PR TITLE
chore: fix Python Publishing Creds.

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           cloudrepo_user: ${{ secrets.CLOUDREPO_USER }}
           cloudrepo_password: ${{ secrets.CLOUDREPO_PASSWORD }}
-          twine_password: ${{ secrets.TWINE_PASSWORD }}
-          twine_username: ${{ secrets.TWINE_USERNAME }}
+          twine_password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+          twine_username: ${{ secrets.PYPI_UPLOAD_USER }}
           npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -37,6 +37,6 @@ jobs:
         with:
           cloudrepo_user: ${{ secrets.CLOUDREPO_USER }}
           cloudrepo_password: ${{ secrets.CLOUDREPO_PASSWORD }}
-          twine_password: ${{ secrets.TWINE_PASSWORD }}
-          twine_username: ${{ secrets.TWINE_USERNAME }}
+          twine_password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+          twine_username: ${{ secrets.PYPI_UPLOAD_USER }}
           npm_token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Looks like the Python publishing creds are incorrect:
* master fails [here](https://github.com/airbytehq/airbyte-protocol/actions/runs/14138575451/job/39615810115#step:4:891).
* manual test with same creds off main fails [here](https://github.com/airbytehq/airbyte-protocol/actions/runs/14210518255/job/39816728688#step:3:890).

I've regenerated them and confirmed they work via a successful manual publish off this branch: https://github.com/airbytehq/airbyte-protocol/actions/runs/14210797370/job/39817514819

This PR updates these to the correct secrets. I'll remove the old secrets after this.