### PR TITLE
feat: add data activation sync modes

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -584,6 +584,10 @@ definitions:
       - overwrite
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
+      - insert
+      - update
+      - upsert
+      - soft_delete
   # Deprecated
   OAuth2Specification:
     type: object


### PR DESCRIPTION
## What

Data Activation has different sync modes that are different than the current modes. Those need to be advertised by the destination in the spec so that they can be selected by the user [here](https://www.figma.com/design/6KSi4J72y8MwtTfCzc5AZo/Data-activation?node-id=220-5692&t=jFBoVTxLAbhiOZej-4) and passed back as part of the configured catalog during `write` commands.

## How

Adding the four new modes under `DestinationSyncMode`