### PR TITLE
feat: rename schema to json-schema

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -610,7 +610,7 @@ definitions:
     required:
       - object_name
       - sync_mode
-      - schema
+      - json_schema
     properties:
       object_name:
         description: The name of the destination object.
@@ -618,7 +618,7 @@ definitions:
       sync_mode:
         description: The sync mode to be performed on the destination object.
         "$ref": "#/definitions/DestinationSyncMode"
-      schema:
+      json_schema:
         description: Stream schema using Json Schema specs.
         type: object
         existingJavaType: com.fasterxml.jackson.databind.JsonNode

--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -613,7 +613,7 @@ definitions:
     required:
       - object_name
       - sync_mode
-      - schema
+      - json_schema
     properties:
       object_name:
         description: The name of the destination object.
@@ -621,7 +621,7 @@ definitions:
       sync_mode:
         description: The sync mode to be performed on the destination object.
         "$ref": "#/definitions/DestinationSyncMode"
-      schema:
+      json_schema:
         description: Stream schema using Json Schema specs.
         type: object
         existingJavaType: com.fasterxml.jackson.databind.JsonNode


### PR DESCRIPTION
## What

I was trying to update destination-salesforce and destination-customer-io with the latest changes and the fact that the field for the json schema is called `schema` clashes with pydantic reserved word `schema` which has the side effect of having the field named as `schema_` instead of `schema`. This problem occurs in two places:
* The python code where we need to write `schema_` instead of just `schema`. I’m not too attached to fixing this right now because we were looking into having the destinations in Kotlin but it is bad DX
* The serialization of the Airbyte message for the discovered catalog generates objects with field `schema_` instead of `schema` and this one is an issue as it does not allow us to return the right object

 There are a couple of paths forward I see:
1. Fix the generation of the python dataclasses to consider the alias: I created [a commit from a fork of the repo that generates our dataclasses](https://github.com/koxudaxi/datamodel-code-generator/commit/30af79085d7735ee8928661ae1db0b24430b1a85) but I would assume that we would need mode development like a feature switch and I don’t know enough the code so there would be more work here. This would fix both problems but we depend on the repo we use to accept our feature
2. Keep `_schema` in Python but fix the serialization [as such](https://github.com/airbytehq/airbyte-python-cdk/pull/527/commits/94209aa0ef47078890d28ff57f59d77907db8cbf)
3. Rename `schema` to `json_schema` [here](https://github.com/airbytehq/airbyte-protocol/blob/main/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml#L621) and avoid the Python dataclass naming project altogether but it’ll require us to update existing code (basically update `schema` to `json_schema`

For now, we decided to go with solution 3