### PR TITLE
feat: add rejected record stats support

### DIFF
--- a/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
+++ b/protocol-models/src/main/resources/airbyte_protocol/v0/airbyte_protocol.yaml
@@ -224,6 +224,11 @@ definitions:
       recordCount:
         description: "the number of records which were emitted for this state message, for this stream or global. While the value should always be a round number, it is defined as a double to account for integer overflows, and the value should always have a decimal point for proper serialization."
         type: number
+      rejectedRecordCount:
+        description: >
+          the number of records which were rejected for this state message, for this stream or global. While the value should always be a
+          round number, it is defined as a double to account for integer overflows, and the value should always have a decimal point for proper serialization.
+        type: number
   AirbyteLogMessage:
     type: object
     additionalProperties: true


### PR DESCRIPTION
For API destinations, there is a notion of records being rejected. Those records were successfully submitted to the destination, however the destination decided to reject the records. Common errors could be invalid format or missing data such as a matching key for example.

Records were processed correctly on our end, it makes sense to be able to checkpoint as usual. We do not want to be retrying those records as we expect the same failure to happen and it would incur increasing cost for our users due to how data activation destinations typically charge.

With this in mind, it makes sense to follow the pattern we use to report loaded records by the destination.

This PR adds a `rejectedRecordCount` to the `AirbyteStateStats`.